### PR TITLE
Many Fixes, Features, Performance, And Fewer Lines

### DIFF
--- a/src/json-viewer.css
+++ b/src/json-viewer.css
@@ -15,9 +15,12 @@
 	display: none;
 }
 
-.json-viewer ul li .type-string,
-.json-viewer ul li .type-date {
+.json-viewer ul li .type-string, {
 	color: #0B7500;
+}
+
+.json-viewer ul li .type-date {
+	color: #CB7500;
 }
 
 .json-viewer ul li .type-boolean {
@@ -29,8 +32,8 @@
 	color: #1A01CC;
 }
 
-.json-viewer ul li .type-null {
-	color: red;
+.json-viewer ul li .type-null, .json-viewer ul li .type-undefined {
+	color: #90a;
 }
 
 .json-viewer a.list-link {

--- a/src/json-viewer.css
+++ b/src/json-viewer.css
@@ -15,7 +15,7 @@
 	display: none;
 }
 
-.json-viewer ul li .type-string, {
+.json-viewer ul li .type-string {
 	color: #0B7500;
 }
 

--- a/src/json-viewer.css
+++ b/src/json-viewer.css
@@ -15,24 +15,24 @@
 	display: none;
 }
 
-.json-viewer ul li .type-string {
+.json-viewer .type-string {
 	color: #0B7500;
 }
 
-.json-viewer ul li .type-date {
+.json-viewer .type-date {
 	color: #CB7500;
 }
 
-.json-viewer ul li .type-boolean {
+.json-viewer .type-boolean {
 	color: #1A01CC;
 	font-weight: bold;
 }
 
-.json-viewer ul li .type-number {
+.json-viewer .type-number {
 	color: #1A01CC;
 }
 
-.json-viewer ul li .type-null, .json-viewer ul li .type-undefined {
+.json-viewer .type-null, .json-viewer .type-undefined {
 	color: #90a;
 }
 

--- a/src/json-viewer.js
+++ b/src/json-viewer.js
@@ -1,11 +1,15 @@
 /**
  * JSONViewer - by Roman Makudera 2016 (c) MIT licence.
  */
-var JSONViewer = (function() {
-	var JSONViewer = function() {
-		this._dom = {};
-		this._dom.container = document.createElement("pre");
-		this._dom.container.classList.add("json-viewer");
+var JSONViewer = (function(document) {
+	var Object_prototype_toString = ({}).toString;
+	var DatePrototypeString = Object_prototype_toString.call(new Date);
+
+
+	/** @constructor */
+	function JSONViewer() {
+		this._dom_container = document.createElement("pre");
+		this._dom_container.classList.add("json-viewer");
 	};
 
 	/**
@@ -15,15 +19,14 @@ var JSONViewer = (function() {
 	 * @param {Number} [maxLvl] Process only to max level, where 0..n, -1 unlimited
 	 * @param {Number} [colAt] Collapse at level, where 0..n, -1 unlimited
 	 */
-	JSONViewer.prototype.showJSON = function(json, maxLvl, colAt) {
-		maxLvl = typeof maxLvl === "number" ? maxLvl : -1; // max level
-		colAt = typeof colAt === "number" ? colAt : -1; // collapse at
-
-		var jsonData = this._processInput(json);
-		var walkEl = this._walk(jsonData, maxLvl, colAt, 0);
-
-		this._dom.container.innerHTML = "";
-		this._dom.container.appendChild(walkEl);
+	JSONViewer.prototype.showJSON = function(jsonValue) {
+		var maxLvl = typeof maxLvl === "number" ? maxLvl : -1; // max level
+		var colAt = typeof colAt === "number" ? colAt : -1; // collapse at
+		
+		this.value = jsonValue;
+		
+		this._dom_container.innerHTML = "";
+		walkJSONTree(this._dom_container, jsonValue, maxLvl, colAt, 0);
 	};
 
 	/**
@@ -32,190 +35,172 @@ var JSONViewer = (function() {
 	 * @return {Element}
 	 */
 	JSONViewer.prototype.getContainer = function() {
-		return this._dom.container;
-	};
-
-	/**
-	 * Process input JSON - throws exception for unrecognized input.
-	 * 
-	 * @param {Object|Array} json Input value
-	 * @return {Object|Array}
-	 */
-	JSONViewer.prototype._processInput = function(json) {
-		if (json && typeof json === "object") {
-			return json;
-		}
-		else {
-			throw "Input value is not object or array!";
-		}
+		return this._dom_container;
 	};
 
 	/**
 	 * Recursive walk for input value.
 	 * 
+	 * @param {Element} outputParent is the Element that will contain the new DOM
 	 * @param {Object|Array} value Input value
 	 * @param {Number} maxLvl Process only to max level, where 0..n, -1 unlimited
 	 * @param {Number} colAt Collapse at level, where 0..n, -1 unlimited
 	 * @param {Number} lvl Current level
+	 * @return {DocumentFragment}
 	 */
-	JSONViewer.prototype._walk = function(value, maxLvl, colAt, lvl) {
-		var frag = document.createDocumentFragment();
-		var isMaxLvl = maxLvl >= 0 && lvl >= maxLvl;
-		var isCollapse = colAt >= 0 && lvl >= colAt;
+	function walkJSONTree(outputParent, value, maxLvl, colAt, lvl) {
+		var realValue = typeof value === "object" && value !== null && "toJSON" in value ? value.toJSON() : value;
+		if (typeof realValue === "object" && realValue !== null) {
+			var frag = document.createDocumentFragment();
+			var isMaxLvl = maxLvl >= 0 && lvl >= maxLvl;
+			var isCollapse = colAt >= 0 && lvl >= colAt;
+			
+			var isArray = Array.isArray(realValue);
+			var items = isArray ? realValue : Object.keys(realValue);
 
-		switch (typeof value) {
-			case "object":
-				if (value) {
-					var isArray = Array.isArray(value);
-					var items = isArray ? value : Object.keys(value);
+			if (lvl === 0) {
+				// root level
+				var rootCount = _createItemsCount(items.length);
+				// hide/show
+				var rootLink = _createLink(isArray ? "[" : "{");
 
-					if (lvl === 0) {
-						// root level
-						var rootCount = this._createItemsCount(items.length);
-						// hide/show
-						var rootLink = this._createLink(isArray ? "[" : "{");
+				if (items.length) {
+					rootLink.addEventListener("click", function() {
+						if (isMaxLvl) return;
 
-						if (items.length) {
-							rootLink.addEventListener("click", function() {
-								if (isMaxLvl) return;
+						rootLink.classList.toggle("collapsed");
+						rootCount.classList.toggle("hide");
 
-								rootLink.classList.toggle("collapsed");
-								rootCount.classList.toggle("hide");
+						// main list
+						outputParent.querySelector("ul").classList.toggle("hide");
+					});
 
-								// main list
-								this._dom.container.querySelector("ul").classList.toggle("hide");
-							}.bind(this));
-
-							if (isCollapse) {
-								rootLink.classList.add("collapsed");
-								rootCount.classList.remove("hide");
-							}
-						}
-						else {
-							rootLink.classList.add("empty");
-						}
-
-						rootLink.appendChild(rootCount);
-						frag.appendChild(rootLink);
+					if (isCollapse) {
+						rootLink.classList.add("collapsed");
+						rootCount.classList.remove("hide");
 					}
-
-					if (items.length && !isMaxLvl) {
-						var len = items.length - 1;
-						var ulList = document.createElement("ul");
-						ulList.setAttribute("data-level", lvl);
-						ulList.classList.add("type-" + (isArray ? "array" : "object"));
-
-						items.forEach(function(key, ind) {
-							var item = isArray ? key : value[key];
-							var li = document.createElement("li");
-
-							if (typeof item === "object") {
-								var isEmpty = false;
-
-								// null && date
-								if (!item || item instanceof Date) {
-									li.appendChild(document.createTextNode(isArray ? "" : key + ": "));
-									li.appendChild(this._createSimple(item ? item : null));
-								}
-								// array & object
-								else {
-									var itemIsArray = Array.isArray(item);
-									var itemLen = itemIsArray ? item.length : Object.keys(item).length;
-
-									// empty
-									if (!itemLen) {
-										li.appendChild(document.createTextNode(key + ": " + (itemIsArray ? "[]" : "{}")));
-									}
-									else {
-										// 1+ items
-										var itemTitle = (typeof key === "string" ? key + ": " : "") + (itemIsArray ? "[" : "{");
-										var itemLink = this._createLink(itemTitle);
-										var itemsCount = this._createItemsCount(itemLen);
-
-										// maxLvl - only text, no link
-										if (maxLvl >= 0 && lvl + 1 >= maxLvl) {
-											li.appendChild(document.createTextNode(itemTitle));
-										}
-										else {
-											itemLink.appendChild(itemsCount);
-											li.appendChild(itemLink);
-										}
-
-										li.appendChild(this._walk(item, maxLvl, colAt, lvl + 1));
-										li.appendChild(document.createTextNode(itemIsArray ? "]" : "}"));
-										
-										var list = li.querySelector("ul");
-										var itemLinkCb = function() {
-											itemLink.classList.toggle("collapsed");
-											itemsCount.classList.toggle("hide");
-											list.classList.toggle("hide");
-										};
-
-										// hide/show
-										itemLink.addEventListener("click", itemLinkCb);
-
-										// collapse lower level
-										if (colAt >= 0 && lvl + 1 >= colAt) {
-											itemLinkCb();
-										}
-									}
-								}
-							}
-							// simple values
-							else {
-								// object keys with key:
-								if (!isArray) {
-									li.appendChild(document.createTextNode(key + ": "));
-								}
-
-								// recursive
-								li.appendChild(this._walk(item, maxLvl, colAt, lvl + 1));
-							}
-
-							// add comma to the end
-							if (ind < len) {
-								li.appendChild(document.createTextNode(","));
-							}
-
-							ulList.appendChild(li);
-						}, this);
-
-						frag.appendChild(ulList);
-					}
-					else if (items.length && isMaxLvl) {
-						var itemsCount = this._createItemsCount(items.length);
-						itemsCount.classList.remove("hide");
-
-						frag.appendChild(itemsCount);
-					}
-
-					if (lvl === 0) {
-						// empty root
-						if (!items.length) {
-							var itemsCount = this._createItemsCount(0);
-							itemsCount.classList.remove("hide");
-
-							frag.appendChild(itemsCount);
-						}
-
-						// root cover
-						frag.appendChild(document.createTextNode(isArray ? "]" : "}"));
-
-						// collapse
-						if (isCollapse) {
-							frag.querySelector("ul").classList.add("hide");
-						}
-					}
-					break;
+				}
+				else {
+					rootLink.classList.add("empty");
 				}
 
-			default:
-				// simple values
-				frag.appendChild(this._createSimple(value));
-				break;
-		}
+				rootLink.appendChild(rootCount);
+				outputParent.appendChild(rootLink); // output the rootLink
+			}
 
-		return frag;
+			if (items.length && !isMaxLvl) {
+				var len = items.length - 1;
+				var ulList = document.createElement("ul");
+				ulList.setAttribute("data-level", lvl);
+				ulList.classList.add("type-" + (isArray ? "array" : "object"));
+
+				items.forEach(function(key, ind) {
+					var item = isArray ? key : value[key];
+					var li = document.createElement("li");
+
+					if (typeof item === "object") {
+						var isEmpty = false;
+
+						// null && date
+						if (!item || item instanceof Date) {
+							li.appendChild(document.createTextNode(isArray ? "" : key + ": "));
+							li.appendChild(createSimpleViewOf(item ? item : null));
+						}
+						// array & object
+						else {
+							var itemIsArray = Array.isArray(item);
+							var itemLen = itemIsArray ? item.length : Object.keys(item).length;
+
+							// empty
+							if (!itemLen) {
+								li.appendChild(document.createTextNode(key + ": " + (itemIsArray ? "[]" : "{}")));
+							}
+							else {
+								// 1+ items
+								var itemTitle = (typeof key === "string" ? key + ": " : "") + (itemIsArray ? "[" : "{");
+								var itemLink = _createLink(itemTitle);
+								var itemsCount = _createItemsCount(itemLen);
+
+								// maxLvl - only text, no link
+								if (maxLvl >= 0 && lvl + 1 >= maxLvl) {
+									li.appendChild(document.createTextNode(itemTitle));
+								}
+								else {
+									itemLink.appendChild(itemsCount);
+									li.appendChild(itemLink);
+								}
+
+								walkJSONTree(li, item, maxLvl, colAt, lvl + 1);
+								li.appendChild(document.createTextNode(itemIsArray ? "]" : "}"));
+								
+								var list = li.querySelector("ul");
+								var itemLinkCb = function() {
+									itemLink.classList.toggle("collapsed");
+									itemsCount.classList.toggle("hide");
+									list.classList.toggle("hide");
+								};
+
+								// hide/show
+								itemLink.addEventListener("click", itemLinkCb);
+
+								// collapse lower level
+								if (colAt >= 0 && lvl + 1 >= colAt) {
+									itemLinkCb();
+								}
+							}
+						}
+					}
+					// simple values
+					else {
+						// object keys with key:
+						if (!isArray) {
+							li.appendChild(document.createTextNode(key + ": "));
+						}
+
+						// recursive
+						walkJSONTree(li, item, maxLvl, colAt, lvl + 1);
+					}
+
+					// add comma to the end
+					if (ind < len) {
+						li.appendChild(document.createTextNode(","));
+					}
+
+					ulList.appendChild(li);
+				}, this);
+
+				outputParent.appendChild(ulList); // output ulList
+			}
+			else if (items.length && isMaxLvl) {
+				var itemsCount = _createItemsCount(items.length);
+				itemsCount.classList.remove("hide");
+
+				outputParent.appendChild(itemsCount); // output itemsCount
+			}
+
+			if (lvl === 0) {
+				// empty root
+				if (!items.length) {
+					var itemsCount = _createItemsCount(0);
+					itemsCount.classList.remove("hide");
+
+					outputParent.appendChild(itemsCount); // output itemsCount
+				}
+
+				// root cover
+				outputParent.appendChild(document.createTextNode(isArray ? "]" : "}"));
+
+				// collapse
+				if (isCollapse) {
+					outputParent.querySelector("ul").classList.add("hide");
+				}
+			}
+
+			return frag;
+		} else {
+			// simple values
+			outputParent.appendChild( createSimpleViewOf(value) );
+		}
 	};
 
 	/**
@@ -224,28 +209,29 @@ var JSONViewer = (function() {
 	 * @param  {Number|String|null|undefined|Date} value Input value
 	 * @return {Element}
 	 */
-	JSONViewer.prototype._createSimple = function(value) {
+	function createSimpleViewOf(value) {
 		var spanEl = document.createElement("span");
 		var type = typeof value;
-		var txt = value;
+		var asText = "" + value;
 
 		if (type === "string") {
-			txt = '"' + value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;") + '"';
-		}
-		else if (value === null) {
+			asText = '"' + value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;") + '"';
+		} else if (value === null) {
 			type = "null";
-			txt = "null";
-		}
-		else if (value === undefined) {
-			txt = "undefined";
-		}
-		else if (value instanceof Date) {
+			//asText = "null";
+		} else if (Object_prototype_toString.call(value) instanceof Date) {
 			type = "date";
-			txt = value.toString();
+			asText = value.toJSON();//.toString();
 		}
 
 		spanEl.classList.add("type-" + type);
-		spanEl.innerHTML = txt;
+		if ("textContent" in spanEl) {
+			// All non-microsoft browsers
+			spanEl.textContent = asText;
+		} else {
+			// Internet Explorer
+			spanEl.innerText = asText;
+		}
 
 		return spanEl;
 	};
@@ -256,11 +242,10 @@ var JSONViewer = (function() {
 	 * @param  {Number} count Items count
 	 * @return {Element}
 	 */
-	JSONViewer.prototype._createItemsCount = function(count) {
+	function _createItemsCount(count) {
 		var itemsCount = document.createElement("span");
-		itemsCount.classList.add("items-ph");
-		itemsCount.classList.add("hide");
-		itemsCount.innerHTML = this._getItemsTitle(count);
+		itemsCount.className = "items-ph hide";
+		itemsCount.innerHTML = _getItemsTitle(count);
 
 		return itemsCount;
 	};
@@ -271,7 +256,7 @@ var JSONViewer = (function() {
 	 * @param  {String} title Link title
 	 * @return {Element}
 	 */
-	JSONViewer.prototype._createLink = function(title) {
+	function _createLink(title) {
 		var linkEl = document.createElement("a");
 		linkEl.classList.add("list-link");
 		linkEl.href = "javascript:void(0)";
@@ -286,11 +271,11 @@ var JSONViewer = (function() {
 	 * @param  {Number} count Items count
 	 * @return {String}
 	 */
-	JSONViewer.prototype._getItemsTitle = function(count) {
+	function _getItemsTitle(count) {
 		var itemsTxt = count > 1 || count === 0 ? "items" : "item";
 
 		return (count + " " + itemsTxt);
 	};
 
 	return JSONViewer;
-})();
+})(document);

--- a/src/json-viewer.js
+++ b/src/json-viewer.js
@@ -47,7 +47,7 @@ var JSONViewer = (function(document) {
 	 * @param {Number} lvl Current level
 	 */
 	function walkJSONTree(outputParent, value, maxLvl, colAt, lvl) {
-		var isDate = Object_prototype_toString.call(value) ==== DatePrototypeAsString;
+		var isDate = Object_prototype_toString.call(value) === DatePrototypeAsString;
 		var realValue = !isDate && typeof value === "object" && value !== null && "toJSON" in value ? value.toJSON() : value;
 		if (typeof realValue === "object" && realValue !== null && !isDate) {
 			var isMaxLvl = maxLvl >= 0 && lvl >= maxLvl;

--- a/src/json-viewer.js
+++ b/src/json-viewer.js
@@ -2,10 +2,6 @@
  * JSONViewer - by Roman Makudera 2016 (c) MIT licence.
  */
 var JSONViewer = (function(document) {
-	var Object_prototype_toString = ({}).toString;
-	var DatePrototypeString = Object_prototype_toString.call(new Date);
-
-
 	/** @constructor */
 	function JSONViewer() {
 		this._dom_container = document.createElement("pre");

--- a/src/json-viewer.js
+++ b/src/json-viewer.js
@@ -100,7 +100,7 @@ var JSONViewer = (function(document) {
 						// null && date
 						if (!item || item instanceof Date) {
 							li.appendChild(document.createTextNode(isArray ? "" : key + ": "));
-							li.appendChild(createSimpleViewOf(item ? item : null));
+							li.appendChild(createSimpleViewOf(item ? item : null, true));
 						}
 						// array & object
 						else {
@@ -214,12 +214,11 @@ var JSONViewer = (function(document) {
 			type = "null";
 			//asText = "null";
 		} else if (isDate) {
-			type = "Date";
+			type = "date";
 			asText = value.toLocaleString();
 		}
-		// there is no need to take care of Date objects because they have already been delt with by toJSON
 
-		spanEl.classList.add("type-" + type);
+		spanEl.className = "type-" + type;
 		spanEl.textContent = asText;
 
 		return spanEl;

--- a/src/json-viewer.js
+++ b/src/json-viewer.js
@@ -2,6 +2,9 @@
  * JSONViewer - by Roman Makudera 2016 (c) MIT licence.
  */
 var JSONViewer = (function(document) {
+	var Object_prototype_toString = ({}).toString;
+	var DatePrototypeAsString = Object_prototype_toString.call(new Date);
+	
 	/** @constructor */
 	function JSONViewer() {
 		this._dom_container = document.createElement("pre");
@@ -12,11 +15,11 @@ var JSONViewer = (function(document) {
 	 * Visualise JSON object.
 	 * 
 	 * @param {Object|Array} json Input value
-	 * @param {Number} [maxLvl] Process only to max level, where 0..n, -1 unlimited
-	 * @param {Number} [colAt] Collapse at level, where 0..n, -1 unlimited
 	 */
 	JSONViewer.prototype.showJSON = function(jsonValue) {
+		// Process only to maxLvl, where 0..n, -1 unlimited
 		var maxLvl = typeof maxLvl === "number" ? maxLvl : -1; // max level
+		// Collapse at level colAt, where 0..n, -1 unlimited
 		var colAt = typeof colAt === "number" ? colAt : -1; // collapse at
 		
 		this.value = jsonValue;
@@ -42,12 +45,10 @@ var JSONViewer = (function(document) {
 	 * @param {Number} maxLvl Process only to max level, where 0..n, -1 unlimited
 	 * @param {Number} colAt Collapse at level, where 0..n, -1 unlimited
 	 * @param {Number} lvl Current level
-	 * @return {DocumentFragment}
 	 */
 	function walkJSONTree(outputParent, value, maxLvl, colAt, lvl) {
 		var realValue = typeof value === "object" && value !== null && "toJSON" in value ? value.toJSON() : value;
 		if (typeof realValue === "object" && realValue !== null) {
-			var frag = document.createDocumentFragment();
 			var isMaxLvl = maxLvl >= 0 && lvl >= maxLvl;
 			var isCollapse = colAt >= 0 && lvl >= colAt;
 			
@@ -191,8 +192,6 @@ var JSONViewer = (function(document) {
 					outputParent.querySelector("ul").classList.add("hide");
 				}
 			}
-
-			return frag;
 		} else {
 			// simple values
 			outputParent.appendChild( createSimpleViewOf(value) );
@@ -215,7 +214,7 @@ var JSONViewer = (function(document) {
 		} else if (value === null) {
 			type = "null";
 			//asText = "null";
-		} else if (Object_prototype_toString.call(value) instanceof Date) {
+		} else if (Object_prototype_toString.call(value) === DatePrototypeAsString) {
 			type = "date";
 			asText = value.toJSON();//.toString();
 		}


### PR DESCRIPTION
1. Enabled top-level primitive view in both the CSS and JS files.
2. Stop abusing `document.createDocumentFragment` like that. Document fragments are fast for large inserts into currently visible content, but slow for small insertions here and there.
3. Fixed the preview for `Date` objects.
4. Fixed `Date` detection.
5. Support `toJSON` method.
6. Fixed syntax highlighting of `undefined` to be the same color as `null`.
7. Changed color of `null` and `undefined` to be purplish to disambiguate.
8. Changed the color of `Date`s to be rust to disambiguate.
9. Hid private methods to local scope to reduce object prototyping lookup for better performance and smaller size.
10.  Added a JSDoc tag to label JSONViewer as a constructor.

# However, there is something that you must do that I cannot do.
Please add Github Pages to this source repository in the same fashion as [my fork repository](https://github.com/anonyco/json-viewer)  so that people can quickly preview with the demo.